### PR TITLE
CSS: Update Safari from Apple docs (positioning/visibility properties)

### DIFF
--- a/css/properties/direction.json
+++ b/css/properties/direction.json
@@ -33,10 +33,10 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "1.3"
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": "3.1"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/css/properties/max-height.json
+++ b/css/properties/max-height.json
@@ -35,10 +35,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "1"
+              "version_added": "1.3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/css/properties/max-width.json
+++ b/css/properties/max-width.json
@@ -35,10 +35,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "2"
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": null

--- a/css/properties/min-height.json
+++ b/css/properties/min-height.json
@@ -36,10 +36,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "1"
+              "version_added": "1.3"
             },
             "safari_ios": {
-              "version_added": "9"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": null

--- a/css/properties/min-width.json
+++ b/css/properties/min-width.json
@@ -35,10 +35,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "2"
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": null

--- a/css/properties/opacity.json
+++ b/css/properties/opacity.json
@@ -39,11 +39,18 @@
             "opera_android": {
               "version_added": "10.1"
             },
-            "safari": {
-              "version_added": "1.2"
-            },
+            "safari": [
+              {
+                "version_added": "2.0"
+              },
+              {
+                "version_added": "1.1",
+                "version_removed": "2.0",
+                "prefix": "-khtml-"
+              }
+            ],
             "safari_ios": {
-              "version_added": "3.2"
+              "version_added": "1.0"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/css/properties/opacity.json
+++ b/css/properties/opacity.json
@@ -41,16 +41,16 @@
             },
             "safari": [
               {
-                "version_added": "2.0"
+                "version_added": "2"
               },
               {
                 "version_added": "1.1",
-                "version_removed": "2.0",
+                "version_removed": "2",
                 "prefix": "-khtml-"
               }
             ],
             "safari_ios": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/css/properties/zoom.json
+++ b/css/properties/zoom.json
@@ -38,7 +38,7 @@
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "4"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": null


### PR DESCRIPTION
Part of five parts to #1774.  This updates all the Safari (and some Safari iOS data) for CSS properties, based upon Apple documentation that @connorshea found.  This conforms BCD's data to said documentation.