### PR TITLE
Mirror Chrome -> Edge for webextensions/

### DIFF
--- a/webextensions/api/webNavigation.json
+++ b/webextensions/api/webNavigation.json
@@ -549,7 +549,8 @@
                   "version_added": false
                 },
                 "edge": {
-                  "version_added": "14"
+                  "version_added": "14",
+                  "version_removed": "79"
                 },
                 "firefox": {
                   "version_added": "54"

--- a/webextensions/manifest/browser_specific_settings.json
+++ b/webextensions/manifest/browser_specific_settings.json
@@ -9,7 +9,8 @@
               "version_added": false
             },
             "edge": {
-              "version_added": "15"
+              "version_added": "15",
+              "version_removed": "79"
             },
             "firefox": [
               {

--- a/webextensions/manifest/incognito.json
+++ b/webextensions/manifest/incognito.json
@@ -9,7 +9,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "48"
@@ -50,7 +50,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "48"

--- a/webextensions/manifest/storage.json
+++ b/webextensions/manifest/storage.json
@@ -9,7 +9,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -29,7 +29,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false


### PR DESCRIPTION
This is a follow-up to #5564 that I apparently never submitted, whoops!

_This PR is a part of #5214, in mirroring Chromium data over to Edge as per the new Edge version.  This performs three tasks: setting the existing `true` values to `≤18`, mirroring the Chromium data to any entires marked as `null` whilst setting the version to `≤79`, and mirroring the Chromium data to entries marked as `false`.  All of this data has been generated by the mirroring script._