### PR TITLE
Safari supports javascript.builtins.String.matchAll

### DIFF
--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -1492,10 +1492,10 @@
                 "version_added": "52"
               },
               "safari": {
-                "version_added": false
+                "version_added": "13"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "13"
               },
               "samsunginternet_android": {
                 "version_added": false


### PR DESCRIPTION
Safari supports this feature since version 13 (based upon manual testing).  This PR updates the data accordingly.