### PR TITLE
Update Firefox releases

### DIFF
--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -581,23 +581,44 @@
         "79": {
           "release_date": "2020-07-28",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/79",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "79"
         },
         "80": {
           "release_date": "2020-08-25",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/80",
-          "status": "beta",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "80"
         },
         "81": {
           "release_date": "2020-09-22",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/81",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "81"
+        },
+        "82": {
+          "release_date": "2020-10-20",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/82",
+          "status": "nightly",
+          "engine": "Gecko",
+          "engine_version": "82"
+        },
+        "83": {
+          "release_date": "2020-11-17",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/83",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "83"
+        },
+        "84": {
+          "release_date": "2020-12-15",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/84",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "84"
         }
       }
     }


### PR DESCRIPTION
Firefox 80 is released -- this PR updates the browser data accordingly.  It also adds data for Firefox 82-84, as per the dates listed on https://wiki.mozilla.org/Release_Management/Calendar.