### PR TITLE
DOMTokenList: separate whitespace trim/duplicate removal; add versions

### DIFF
--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -831,10 +831,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "55"
+              "version_added": "51"
             },
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "51"
             },
             "ie": {
               "version_added": "10"

--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -527,21 +527,19 @@
           }
         }
       },
-      "remove_whitespace_and_duplicates": {
+      "remove_duplicates": {
         "__compat": {
-          "description": "Trimming of whitespace and removal of duplicates",
+          "description": "Removal of duplicates",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMTokenList#Trimming_of_whitespace_and_removal_of_duplicates",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "60"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "60"
             },
             "edge": {
-              "version_added": "12",
-              "partial_implementation": true,
-              "notes": "Before Edge 79, <code>DOMTokenList</code> trims whitespace but doesn't remove duplicates."
+              "version_added": "17"
             },
             "firefox": {
               "version_added": "55"
@@ -550,15 +548,13 @@
               "version_added": "55"
             },
             "ie": {
-              "version_added": true,
-              "partial_implementation": true,
-              "notes": "<code>DOMTokenList</code> trims whitespace but doesn't remove duplicates."
+              "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "44"
             },
             "safari": {
               "version_added": "10"
@@ -567,10 +563,10 @@
               "version_added": "10"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "60"
             }
           },
           "status": {
@@ -817,6 +813,55 @@
               "standard_track": true,
               "deprecated": false
             }
+          }
+        }
+      },
+      "trim_whitespace": {
+        "__compat": {
+          "description": "Trimming of whitespace",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMTokenList#Trimming_of_whitespace_and_removal_of_duplicates",
+          "support": {
+            "chrome": {
+              "version_added": "48"
+            },
+            "chrome_android": {
+              "version_added": "48"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": "55"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "35"
+            },
+            "opera_android": {
+              "version_added": "35"
+            },
+            "safari": {
+              "version_added": "10"
+            },
+            "safari_ios": {
+              "version_added": "10"
+            },
+            "samsunginternet_android": {
+              "version_added": "5.0"
+            },
+            "webview_android": {
+              "version_added": "48"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },


### PR DESCRIPTION
In `DOMTokenList`, we have an entry about how modifications will trim the whitespace and remove duplicates, with partial implementation notes for IE and Edge about how they trim whitespace but not remove duplicates.  However, from my testing, I've found that Chrome and Firefox also implemented whitespace trimming before duplicate removal.  This PR separates the subfeature into two subfeatures, and adds/fixes versions for both of them.