### PR TITLE
Remove accidental "Edge OS" strings

### DIFF
--- a/api/BluetoothCharacteristicProperties.json
+++ b/api/BluetoothCharacteristicProperties.json
@@ -31,7 +31,7 @@
           "edge": [
             {
               "version_added": "≤79",
-              "notes": "EdgeOS and macOS only."
+              "notes": "macOS only."
             },
             {
               "version_added": "≤79",
@@ -114,7 +114,7 @@
             "edge": [
               {
                 "version_added": "≤79",
-                "notes": "EdgeOS and macOS only."
+                "notes": "macOS only."
               },
               {
                 "version_added": "≤79",
@@ -198,7 +198,7 @@
             "edge": [
               {
                 "version_added": "≤79",
-                "notes": "EdgeOS and macOS only."
+                "notes": "macOS only."
               },
               {
                 "version_added": "≤79",
@@ -282,7 +282,7 @@
             "edge": [
               {
                 "version_added": "≤79",
-                "notes": "EdgeOS and macOS only."
+                "notes": "macOS only."
               },
               {
                 "version_added": "≤79",
@@ -366,7 +366,7 @@
             "edge": [
               {
                 "version_added": "≤79",
-                "notes": "EdgeOS and macOS only."
+                "notes": "macOS only."
               },
               {
                 "version_added": "≤79",
@@ -450,7 +450,7 @@
             "edge": [
               {
                 "version_added": "≤79",
-                "notes": "EdgeOS and macOS only."
+                "notes": "macOS only."
               },
               {
                 "version_added": "≤79",
@@ -534,7 +534,7 @@
             "edge": [
               {
                 "version_added": "≤79",
-                "notes": "EdgeOS and macOS only."
+                "notes": "macOS only."
               },
               {
                 "version_added": "≤79",
@@ -618,7 +618,7 @@
             "edge": [
               {
                 "version_added": "≤79",
-                "notes": "EdgeOS and macOS only."
+                "notes": "macOS only."
               },
               {
                 "version_added": "≤79",
@@ -702,7 +702,7 @@
             "edge": [
               {
                 "version_added": "≤79",
-                "notes": "EdgeOS and macOS only."
+                "notes": "macOS only."
               },
               {
                 "version_added": "≤79",
@@ -786,7 +786,7 @@
             "edge": [
               {
                 "version_added": "≤79",
-                "notes": "EdgeOS and macOS only."
+                "notes": "macOS only."
               },
               {
                 "version_added": "≤79",

--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -275,7 +275,7 @@
               },
               "edge": {
                 "version_added": "≤79",
-                "notes": "On Windows and Edge OS the entire system audio can be captured, but on Linux and Mac only the audio of a tab can be captured."
+                "notes": "On Windows, the entire system audio can be captured, but on Linux and Mac only the audio of a tab can be captured."
               },
               "firefox": {
                 "version_added": false


### PR DESCRIPTION
This PR fixes #6740 by removing instances of "Edge OS" in strings.