### PR TITLE
Set Chromium version for api.MediaDeviceInfo.toJSON

### DIFF
--- a/api/MediaDeviceInfo.json
+++ b/api/MediaDeviceInfo.json
@@ -25,11 +25,11 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false,
+            "version_added": "42",
             "notes": "This interface can be used in Opera by using the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill."
           },
           "opera_android": {
-            "version_added": false,
+            "version_added": "42",
             "notes": "This interface can be used in Opera by using the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill."
           },
           "safari": {

--- a/api/MediaDeviceInfo.json
+++ b/api/MediaDeviceInfo.json
@@ -277,10 +277,10 @@
           "description": "<code>toJSON()</code>",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "55"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "55"
             },
             "edge": {
               "version_added": "18"
@@ -295,11 +295,11 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false,
+              "version_added": "42",
               "notes": "For earlier versions, this method is available through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill"
             },
             "opera_android": {
-              "version_added": false,
+              "version_added": "42",
               "notes": "For earlier versions, this method is available through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill"
             },
             "safari": {
@@ -309,10 +309,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "55"
             }
           },
           "status": {


### PR DESCRIPTION
This PR uses the mdn-bcd-collector to determine the version number for `api.MediaDeviceInfo.toJSON`. 