### PR TITLE
Update data for CSSSupportsRule API

### DIFF
--- a/api/CSSSupportsRule.json
+++ b/api/CSSSupportsRule.json
@@ -5,57 +5,54 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSSupportsRule",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": "41"
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "41"
           },
           "edge": {
-            "version_added": "≤18",
-            "version_removed": "79"
+            "version_added": "12"
           },
           "firefox": {
-            "version_added": "17",
-            "notes": "From Firefox 17 to 19, methods and properties were defined on <code>CSSSupportsRule</code>. From version 20, they were on <code>CSSConditionRule</code>.",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "layout.css.supports-rule.enable",
-                "value_to_set": "true"
-              }
-            ]
+            "version_added": "22",
+            "notes": "Methods and properties are defined on <code>CSSConditionRule</code>."
           },
           "firefox_android": {
-            "version_added": "17",
-            "notes": "From Firefox 17 to 19, methods and properties were defined on <code>CSSSupportsRule</code>. From version 20, they were on <code>CSSConditionRule</code>.",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "layout.css.supports-rule.enable",
-                "value_to_set": "true"
-              }
-            ]
+            "version_added": "22",
+            "notes": "Methods and properties are defined on <code>CSSConditionRule</code>."
           },
           "ie": {
             "version_added": false
           },
-          "opera": {
-            "version_added": "12.1"
-          },
-          "opera_android": {
-            "version_added": false
-          },
+          "opera": [
+            {
+              "version_added": "28"
+            },
+            {
+              "version_added": "12.1",
+              "version_removed": "15"
+            }
+          ],
+          "opera_android": [
+            {
+              "version_added": "28"
+            },
+            {
+              "version_added": "12.1",
+              "version_removed": "14"
+            }
+          ],
           "safari": {
-            "version_added": false
+            "version_added": "10.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "10.3"
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "4.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "41"
           }
         },
         "status": {


### PR DESCRIPTION
This PR updates the compat data for the `CSSSupportsRule` API based upon a combination of results from the mdn-bcd-collector, as well as manual testing.