### PR TITLE
Update Opera data for HTML element APIs

### DIFF
--- a/api/HTMLAreaElement.json
+++ b/api/HTMLAreaElement.json
@@ -214,10 +214,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "41"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "safari": {
               "version_added": true
@@ -454,10 +454,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "41"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "safari": {
               "version_added": true
@@ -502,10 +502,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "41"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "safari": {
               "version_added": true

--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -932,10 +932,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "56"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "48"
             },
             "safari": {
               "version_added": false

--- a/api/HTMLDetailsElement.json
+++ b/api/HTMLDetailsElement.json
@@ -23,10 +23,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "15"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "14"
           },
           "safari": {
             "version_added": true
@@ -70,10 +70,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": true

--- a/api/HTMLDialogElement.json
+++ b/api/HTMLDialogElement.json
@@ -39,7 +39,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "24"
           },
           "opera_android": {
             "version_added": false
@@ -151,7 +151,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "24"
             },
             "opera_android": {
               "version_added": false
@@ -264,7 +264,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "24"
             },
             "opera_android": {
               "version_added": false
@@ -328,7 +328,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "24"
             },
             "opera_android": {
               "version_added": false
@@ -392,7 +392,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "24"
             },
             "opera_android": {
               "version_added": false
@@ -456,7 +456,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "24"
             },
             "opera_android": {
               "version_added": false

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -118,10 +118,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": "14"
@@ -391,10 +391,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "53"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "47"
             },
             "safari": {
               "version_added": null
@@ -904,10 +904,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "64"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "55"
             },
             "safari": {
               "version_added": "13.1"
@@ -1404,10 +1404,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "53"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "47"
             },
             "safari": {
               "version_added": null
@@ -1506,7 +1506,8 @@
               "version_removed": "15"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "11",
+              "version_removed": "14"
             },
             "safari": {
               "version_added": null
@@ -1558,7 +1559,8 @@
               "version_removed": "15"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "11",
+              "version_removed": "14"
             },
             "safari": {
               "version_added": null
@@ -1610,7 +1612,8 @@
               "version_removed": "15"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "11",
+              "version_removed": "14"
             },
             "safari": {
               "version_added": null
@@ -1662,7 +1665,8 @@
               "version_removed": "15"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "11",
+              "version_removed": "14"
             },
             "safari": {
               "version_added": null
@@ -1714,7 +1718,8 @@
               "version_removed": "15"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "11",
+              "version_removed": "14"
             },
             "safari": {
               "version_added": null
@@ -1766,7 +1771,8 @@
               "version_removed": "15"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "11",
+              "version_removed": "14"
             },
             "safari": {
               "version_added": null
@@ -1957,10 +1963,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "48"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "45"
             },
             "safari": {
               "version_added": "10"
@@ -3684,10 +3690,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": "6"

--- a/api/HTMLFieldSetElement.json
+++ b/api/HTMLFieldSetElement.json
@@ -262,10 +262,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": true
@@ -358,10 +358,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": true

--- a/api/HTMLFormElement.json
+++ b/api/HTMLFormElement.json
@@ -166,10 +166,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": true
@@ -647,10 +647,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "27"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "27"
             },
             "safari": {
               "version_added": true

--- a/api/HTMLFrameSetElement.json
+++ b/api/HTMLFrameSetElement.json
@@ -211,10 +211,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": true

--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -935,11 +935,11 @@
               "version_added": null
             },
             "opera": {
-              "version_added": true,
+              "version_added": "15",
               "notes": "Before Opera 37, this property returned the deprecated child <code>DOMSettableTokenList</code> instead of <code>DOMTokenList</code>."
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "14",
               "notes": "Before Opera 37, this property returned the deprecated child <code>DOMSettableTokenList</code> instead of <code>DOMTokenList</code>."
             },
             "safari": {
@@ -1131,10 +1131,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": "6"

--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -432,7 +432,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "51"
+            },
+            "opera_android": {
+              "version_added": "47"
             },
             "safari": {
               "version_added": "11.1"
@@ -477,7 +480,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "52"
+            },
+            "opera_android": {
+              "version_added": "47"
             },
             "safari": {
               "version_added": "11.1"
@@ -1125,10 +1131,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "25"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "25"
             },
             "safari": {
               "version_added": false

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -1331,10 +1331,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "qq_android": {
               "version_added": true
@@ -1653,10 +1653,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "14"
             },
             "safari": {
               "version_added": "11.1"
@@ -1701,10 +1701,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "14"
             },
             "safari": {
               "version_added": "11.1"

--- a/api/HTMLLinkElement.json
+++ b/api/HTMLLinkElement.json
@@ -312,11 +312,11 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true,
+              "version_added": "15",
               "notes": "Before Opera 37, this property returned the deprecated child <code>DOMSettableTokenList</code> instead of <code>DOMTokenList</code>."
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "14",
               "notes": "Before Opera 37, this property returned the deprecated child <code>DOMSettableTokenList</code> instead of <code>DOMTokenList</code>."
             },
             "safari": {

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -294,10 +294,10 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": "30"
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": "30"
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6"
@@ -972,10 +972,10 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "36"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "36"
             },
             "safari": {
               "version_added": true
@@ -1357,7 +1357,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": true
@@ -1736,7 +1739,7 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": null
@@ -1766,7 +1769,7 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": null
@@ -1844,7 +1847,7 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": null
@@ -2248,7 +2251,7 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": null
@@ -2283,7 +2286,7 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": null
@@ -3367,7 +3370,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "36"
             },
             "safari": {
               "version_added": null

--- a/api/HTMLOListElement.json
+++ b/api/HTMLOListElement.json
@@ -118,10 +118,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "5"

--- a/api/HTMLOutputElement.json
+++ b/api/HTMLOutputElement.json
@@ -216,11 +216,11 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true,
+              "version_added": "15",
               "notes": "Before Opera 37, this property returned the deprecated child <code>DOMSettableTokenList</code> instead of <code>DOMTokenList</code>."
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "14",
               "notes": "Before Opera 37, this property returned the deprecated child <code>DOMSettableTokenList</code> instead of <code>DOMTokenList</code>."
             },
             "safari": {
@@ -460,10 +460,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": "5"

--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -69,10 +69,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": false
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": true
@@ -163,10 +163,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": "4"
@@ -264,10 +264,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": true
@@ -311,10 +311,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": true
@@ -432,10 +432,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "57"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "49"
             },
             "safari": {
               "version_added": "14"

--- a/api/HTMLSlotElement.json
+++ b/api/HTMLSlotElement.json
@@ -128,10 +128,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "52"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "47"
             },
             "safari": {
               "version_added": null

--- a/api/HTMLSpanElement.json
+++ b/api/HTMLSpanElement.json
@@ -23,10 +23,10 @@
             "version_added": true
           },
           "opera": {
-            "version_added": true
+            "version_added": "15"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "14"
           },
           "safari": {
             "version_added": true

--- a/api/HTMLTableElement.json
+++ b/api/HTMLTableElement.json
@@ -403,10 +403,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": true

--- a/api/HTMLTextAreaElement.json
+++ b/api/HTMLTextAreaElement.json
@@ -118,10 +118,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "53"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "47"
             },
             "safari": {
               "version_added": true
@@ -262,10 +262,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "30"
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "9"


### PR DESCRIPTION
This PR updates the Opera data for the HTML element APIs based upon results from the mdn-bcd-collector project (using results from Opera 12.14, 15, and 70), followed by additional mirroring from Chrome data.